### PR TITLE
Fix: Emloyee Checkin Time as Per Employee Timezone

### DIFF
--- a/employee_self_service/mobile/v1/api_utils.py
+++ b/employee_self_service/mobile/v1/api_utils.py
@@ -150,3 +150,13 @@ def update_workflow_state(reference_doctype, reference_name, action):
     except Exception as e:
         frappe.db.rollback()
         return exception_handler(e)
+
+
+def convert_timezone(timestamp, from_timestamp, time_zone):
+    from pytz import UnknownTimeZoneError, timezone
+
+    fromtimezone = timezone(from_timestamp).localize(timestamp)
+    try:
+        return fromtimezone.astimezone(timezone(time_zone))
+    except UnknownTimeZoneError:
+        return fromtimezone


### PR DESCRIPTION
If the Employee is in different Timezone than the system timezone,
They will see check-in time in the dashboard as per their Timezone.
Users' Timezone will be taken from User Doctype.